### PR TITLE
Convert builds to GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: Build Lucee Release
 on:
   # Enable manual workflow runs
   workflow_dispatch:
+  # Enable triggering a build via the github API
+  # Or trigger a build from another repo via https://github.com/marketplace/actions/repository-dispatch
   repository_dispatch:
     types: [ forgebox_deploy ]
-  # Enable automated workflow runs from another repo or workflow
-  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Build Lucee Release
+
+on:
+  # Enable manual workflow runs
+  workflow_dispatch:
+  # Enable automated workflow runs from another repo or workflow
+  workflow_call:
+
+jobs:
+  docbox:
+    name: Generate API Docs
+    runs-on: ubuntu-latest
+    container: ghcr.io/foundeo/cfml-ci-tools/cfml-ci-tools:1.0.6
+    if: ${{ github.ref }} == 'master'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: box install --production
+
+      - name: Fetch and publish Lucee releases
+        run: box task run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,16 @@ on:
   workflow_call:
 
 jobs:
-  docbox:
-    name: Generate API Docs
+  build:
+    name: Build Release
     runs-on: ubuntu-latest
     container: ghcr.io/foundeo/cfml-ci-tools/cfml-ci-tools:1.0.6
     if: ${{ github.ref }} == 'master'
+    env:
+      FORGEBOX_TOKEN: ${{ secrets.FORGEBOX_TOKEN }}
+      S3_ACCESS_KEY: test1
+      S3_SECRET: test2
+      SLACK_WEBHOOK_URL: test3
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ name: Build Lucee Release
 on:
   # Enable manual workflow runs
   workflow_dispatch:
+  repository_dispatch:
+    types: [ forgebox_deploy ]
   # Enable automated workflow runs from another repo or workflow
   workflow_call:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     container: ghcr.io/foundeo/cfml-ci-tools/cfml-ci-tools:1.0.6
     if: ${{ github.ref }} == 'master'
     env:
-      FORGEBOX_TOKEN: ${{ secrets.FORGEBOX_TOKEN }}
-      S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
-      S3_SECRET: ${{ secrets.S3_SECRET }}
+      FORGEBOX_TOKEN: ${{ secrets.FORGEBOX_API_TOKEN }}
+      S3_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+      S3_SECRET: ${{ secrets.AWS_ACCESS_SECRET }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
     if: ${{ github.ref }} == 'master'
     env:
       FORGEBOX_TOKEN: ${{ secrets.FORGEBOX_TOKEN }}
-      S3_ACCESS_KEY: test1
-      S3_SECRET: test2
-      SLACK_WEBHOOK_URL: test3
+      S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+      S3_SECRET: ${{ secrets.S3_SECRET }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR will convert the Forgebox CFEngine pusher to GitHub Actions.

## Prior to Merge

Before merging, PLEASE:

1. Add secrets to the forgebox-cfengine-publisher repo:
  * `FORGEBOX_TOKEN`
  * `S3_ACCESS_KEY`
  * `S3_SECRET`
  * `SLACK_WEBHOOK_URL`
  * (these may already be configured at the organization level.)
2. Send LAS an access token. The only permission it needs is `repo.public_repo`: _"Access public repositories"_.

## After Merge

Once this PR is merged, instruct Lucee on triggering this build from their own github actions build. To do this:

1. Create a `PAT` repository secret containing the Ortus Solutions-created personal access token with "public_repo" permission
2. Add the following as a step in the Lucee workflow:

```yml
      - name: Push to ForgeBox
        uses: peter-evans/repository-dispatch@v1.1.3
        with:
          repository: Ortus-Solutions/forgebox-cfengine-publisher
          token: ${{ secrets.PAT }}
          event-type: forgebox_deploy
```